### PR TITLE
Adds wmi x_wmi_not_found Exception

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -38,6 +38,10 @@ class x_wmi_timed_out(x_wmi):
     pass
 
 
+class x_wmi_not_found(x_wmi):
+    pass
+
+
 class com_error(Exception):
     def __init__(self, hresult, strerror, excepinfo, argerror):
         self.hresult = hresult
@@ -550,7 +554,7 @@ def _unwrap_element(el_type, value):
         if el_type == mi.MI_REFERENCE:
             instance = WMI(value)
             if instance is None:
-                raise Exception("Reference not found: %s" % value)
+                raise x_wmi_not_found("Reference not found: %s" % value)
             return instance._instance
         elif el_type == mi.MI_INSTANCE:
             return value._instance


### PR DESCRIPTION
Adds the x_wmi_not_found WMI exception.
Raises x_wmi_not_found exception if the given
element was not found.
