### PR TITLE
wmi: Makes _get_method_params thread safe

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -409,8 +409,7 @@ class _Connection(object):
                 mi_class, six.text_type(method_name))
             if self._cache_classes:
                 self._method_params_cache[(class_name, method_name)] = params
-                params = params.clone()
-        return params
+        return params.clone()
 
     @mi_to_wmi_exception
     def invoke_method(self, target, method_name, *args, **kwargs):


### PR DESCRIPTION
_get_method_params is supposed to return a unique Object
in which a method's parameters are mapped. The issue is that
it always returns the same object, which can be modified by
multiple threads, leading to erroneous method calls.

Method now returns a cloned object.
