### PR TITLE
Fixes get_class when the class has no attributes

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -481,7 +481,7 @@ class _Connection(object):
                     if self._cache_classes:
                         self._class_cache[class_name] = cls
 
-        if cls:
+        if cls is not None:
             return _Class(self, class_name, cls)
 
     @mi_to_wmi_exception


### PR DESCRIPTION
Doing "if cls:" will return False in the case in
which the class has no attributes. The class implements
the method **len**() which returns the number of class
attributes and which is also used to test the truth value
of "if cls:". In the case in which the class has only
methods, the truth value will be False even if the object exists.

It is better to compare the reference of cls with None.
