### PR TITLE
Fixes PyMI compatibility with WMI in case of association classes

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -537,13 +537,13 @@ def _wrap_element(conn, name, el_type, value):
         if el_type == mi.MI_INSTANCE:
             return _Instance(conn, value.clone())
         elif el_type == mi.MI_REFERENCE:
-            return value.get_path()
+            return WMI(value.get_path())
         else:
             raise Exception(
                 "Unsupported instance element type: %s" % el_type)
     if isinstance(value, (tuple, list)):
         if el_type == mi.MI_REFERENCEA:
-            return tuple([i.get_path() for i in value])
+            return tuple([WMI(i.get_path()) for i in value])
         elif el_type == mi.MI_INSTANCEA:
             return tuple([_Instance(conn, i.clone()) for i in value])
         else:


### PR DESCRIPTION
Currently, in the case of association classes, PyMI returns only
the references to the associated objects as strings, while WMI
converts them and returns the objects.

This patch changes the behaviour of PyMI in case of association
classes by returning the objects as WMI does.
