### PR TITLE
Removes unnecessary try-except

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -496,14 +496,11 @@ class _Connection(object):
         key_instance = self.new_instance_from_class(c)
         for k, v in key.items():
             key_instance._instance[six.text_type(k)] = v
-        try:
-            with self._session.get_instance(
-                    self._ns, key_instance._instance) as op:
-                instance = op.get_next_instance()
-                if instance:
-                    return _Instance(self, instance.clone())
-        except mi.error:
-            return None
+        with self._session.get_instance(
+                self._ns, key_instance._instance) as op:
+            instance = op.get_next_instance()
+            if instance:
+                return _Instance(self, instance.clone())
 
     @mi_to_wmi_exception
     def create_instance(self, instance):


### PR DESCRIPTION
The try-except isn't needed anymore since there is already
the mi_to_wmi_exception wrapper which takes care of the error
handling.

This also fixes a compatibility issue with the old WMI in the way
errors are handled. The old WMI is raising an exception in this
case while PyMI is ignoring the exception and returns None.
