### PR TITLE
Forbid setting array items to NULL

### DIFF
--- a/MI/MIValue.cpp
+++ b/MI/MIValue.cpp
@@ -122,6 +122,10 @@ void MIValue::SetArrayItem(const MIValue& value, MI_Uint32 index)
             strDest = new MI_Char[len];
             memcpy_s(strDest, len * sizeof(MI_Char), value.m_value.string, len * sizeof(MI_Char));
         }
+        else
+        {
+            throw Exception(L"Array item cannot be NULL");
+        }
         memcpy_s(&m_value.uint8a.data[index * itemSize], itemSize, &strDest, itemSize);
     }
     else


### PR DESCRIPTION
At the moment, doing this will crash PyMI with an access
violation error when the according instance object is
serialized.

We'll simply throw an exception if this is requested.
