### PR TITLE
Fixes moniker parsing when value is missing quotes

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -660,6 +660,8 @@ def _parse_moniker(moniker):
                 class_name, kvs = m.groups()
                 for kv in kvs.split(","):
                     m = re.match("([^=]+)=\"(.*)\"", kv)
+                    if not m:
+                        m = re.match("([^=]+)=(.*)", kv)
                     name, value = m.groups()
                     # TODO: improve unescaping
                     key[name] = value.replace("//", "\\")


### PR DESCRIPTION
In some cases the variable might miss the quotes
around the value, in which case the parsing fails.

This patch addresses this issue by changing the
quotes around the value to be optional and not
mandatory.
