### PR TITLE
Add operation timeout support

### DIFF
--- a/MI/MI++.cpp
+++ b/MI/MI++.cpp
@@ -655,7 +655,6 @@ std::shared_ptr<OperationOptions> OperationOptions::Clone() const
     return std::shared_ptr<OperationOptions>(new OperationOptions(clonedOperationOptions));
 }
 
-
 void OperationOptions::Delete()
 {
     ::MI_OperationOptions_Delete(&this->m_operationOptions);
@@ -681,6 +680,18 @@ std::wstring DestinationOptions::GetUILocale()
     const MI_Char* locale;
     MICheckResult(::MI_DestinationOptions_GetUILocale(&this->m_destinationOptions, &locale));
     return locale;
+}
+
+void DestinationOptions::SetTimeout(const MI_Interval& timeout)
+{
+    MICheckResult(::MI_DestinationOptions_SetTimeout(&this->m_destinationOptions, &timeout));
+}
+
+MI_Interval DestinationOptions::GetTimeout()
+{
+    MI_Interval timeout;
+    MICheckResult(::MI_DestinationOptions_GetTimeout(&this->m_destinationOptions, &timeout));
+    return timeout;
 }
 
 std::shared_ptr<DestinationOptions> DestinationOptions::Clone() const

--- a/MI/MI++.cpp
+++ b/MI/MI++.cpp
@@ -743,20 +743,27 @@ Session::~Session()
     }
 }
 
-std::shared_ptr<Operation> Session::ExecQuery(const std::wstring& ns, const std::wstring& query, const std::wstring& dialect)
+std::shared_ptr<Operation> Session::ExecQuery(const std::wstring& ns, const std::wstring& query, const std::wstring& dialect,
+                                              std::shared_ptr<OperationOptions> operationOptions)
 {
     MI_Operation op = MI_OPERATION_NULL;
-    ::MI_Session_QueryInstances(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI, nullptr, ns.c_str(), dialect.c_str(),
+    ::MI_Session_QueryInstances(
+        &this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI,
+        operationOptions ? &operationOptions->m_operationOptions : nullptr,
+        ns.c_str(), dialect.c_str(),
         query.c_str(), nullptr, &op);
     return std::make_shared<Operation>(op);
 }
 
 std::shared_ptr<Operation> Session::GetAssociators(const std::wstring& ns, const Instance& instance, const std::wstring& assocClass,
-    const std::wstring& resultClass, const std::wstring& role, const std::wstring& resultRole, bool keysOnly)
+    const std::wstring& resultClass, const std::wstring& role, const std::wstring& resultRole, bool keysOnly,
+    std::shared_ptr<OperationOptions> operationOptions)
 {
     MI_Operation op = MI_OPERATION_NULL;
     ::MI_Session_AssociatorInstances(
-        &this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI, nullptr, ns.c_str(), instance.m_instance,
+        &this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI,
+        operationOptions ? &operationOptions->m_operationOptions : nullptr,
+        ns.c_str(), instance.m_instance,
         assocClass.length() ? assocClass.c_str() : nullptr,
         resultClass.length() ? resultClass.c_str() : nullptr,
         role.length() ? role.c_str() : nullptr,
@@ -766,31 +773,38 @@ std::shared_ptr<Operation> Session::GetAssociators(const std::wstring& ns, const
 }
 
 std::shared_ptr<Operation> Session::InvokeMethod(
-    Instance& instance, const std::wstring& methodName, std::shared_ptr<const Instance> inboundParams)
+    Instance& instance, const std::wstring& methodName, std::shared_ptr<const Instance> inboundParams,
+    std::shared_ptr<OperationOptions> operationOptions)
 {
     MI_Operation op = MI_OPERATION_NULL;
     ::MI_Session_Invoke(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI,
-        nullptr, instance.GetNameSpace().c_str(), instance.GetClassName().c_str(), methodName.c_str(), instance.m_instance,
+        operationOptions ? &operationOptions->m_operationOptions : nullptr,
+        instance.GetNameSpace().c_str(), instance.GetClassName().c_str(), methodName.c_str(), instance.m_instance,
         inboundParams && inboundParams->GetElementsCount() > 0 ? inboundParams->m_instance : nullptr,
         nullptr, &op);
     return std::make_shared<Operation>(op);
 }
 
 std::shared_ptr<Operation> Session::InvokeMethod(
-    const std::wstring& ns, const std::wstring& className, const std::wstring& methodName, std::shared_ptr<const Instance> inboundParams)
+    const std::wstring& ns, const std::wstring& className, const std::wstring& methodName, std::shared_ptr<const Instance> inboundParams,
+    std::shared_ptr<OperationOptions> operationOptions)
 {
     MI_Operation op = MI_OPERATION_NULL;
     ::MI_Session_Invoke(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI,
-        nullptr, ns.c_str(), className.c_str(), methodName.c_str(), nullptr,
+        operationOptions ? &operationOptions->m_operationOptions : nullptr,
+        ns.c_str(), className.c_str(), methodName.c_str(), nullptr,
         inboundParams && inboundParams->GetElementsCount() > 0 ? inboundParams->m_instance : nullptr,
         nullptr, &op);
     return std::make_shared<Operation>(op);
 }
 
-void Session::DeleteInstance(const std::wstring& ns, const Instance& instance)
+void Session::DeleteInstance(const std::wstring& ns, const Instance& instance,
+                             std::shared_ptr<OperationOptions> operationOptions)
 {
     MI_Operation op;
-    ::MI_Session_DeleteInstance(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI, nullptr, ns.c_str(), instance.m_instance, nullptr, &op);
+    ::MI_Session_DeleteInstance(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI,
+		                        operationOptions ? &operationOptions->m_operationOptions : nullptr,
+                                ns.c_str(), instance.m_instance, nullptr, &op);
     Operation operation(op);
     while (operation.HasMoreResults())
     {
@@ -798,10 +812,13 @@ void Session::DeleteInstance(const std::wstring& ns, const Instance& instance)
     }
 }
 
-void Session::ModifyInstance(const std::wstring& ns, const Instance& instance)
+void Session::ModifyInstance(const std::wstring& ns, const Instance& instance,
+                             std::shared_ptr<OperationOptions> operationOptions)
 {
     MI_Operation op;
-    ::MI_Session_ModifyInstance(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI, nullptr, ns.c_str(), instance.m_instance, nullptr, &op);
+    ::MI_Session_ModifyInstance(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI,
+                                operationOptions ? &operationOptions->m_operationOptions : nullptr,
+                                ns.c_str(), instance.m_instance, nullptr, &op);
     Operation operation(op);
     while (operation.HasMoreResults())
     {
@@ -809,10 +826,13 @@ void Session::ModifyInstance(const std::wstring& ns, const Instance& instance)
     }
 }
 
-void Session::CreateInstance(const std::wstring& ns, const Instance& instance)
+void Session::CreateInstance(const std::wstring& ns, const Instance& instance,
+                             std::shared_ptr<OperationOptions> operationOptions)
 {
     MI_Operation op;
-    ::MI_Session_CreateInstance(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI, nullptr, ns.c_str(), instance.m_instance, nullptr, &op);
+    ::MI_Session_CreateInstance(&this->m_session, MI_OPERATIONFLAGS_DEFAULT_RTTI,
+                                operationOptions ? &operationOptions->m_operationOptions : nullptr,
+                                ns.c_str(), instance.m_instance, nullptr, &op);
     Operation operation(op);
     while (operation.HasMoreResults())
     {

--- a/MI/MI++.h
+++ b/MI/MI++.h
@@ -107,6 +107,8 @@ namespace MI
 
     public:
         std::shared_ptr<DestinationOptions> Clone() const;
+        void SetTimeout(const MI_Interval& timeout);
+        MI_Interval GetTimeout();
         void SetUILocale(const std::wstring& locale);
         std::wstring GetUILocale();
         void Delete();

--- a/MI/MI++.h
+++ b/MI/MI++.h
@@ -125,19 +125,27 @@ namespace MI
         friend Application;
 
     public:
-        std::shared_ptr<Operation> ExecQuery(const std::wstring& ns, const std::wstring& query, const std::wstring& dialect = L"WQL");
+        std::shared_ptr<Operation> ExecQuery(const std::wstring& ns, const std::wstring& query,
+                                             const std::wstring& dialect = L"WQL",
+                                             std::shared_ptr<OperationOptions> operationOptions = nullptr);
         std::shared_ptr<Operation> InvokeMethod(
-            Instance& instance, const std::wstring& methodName, std::shared_ptr<const Instance> inboundParams);
+            Instance& instance, const std::wstring& methodName, std::shared_ptr<const Instance> inboundParams,
+            std::shared_ptr<OperationOptions> operationOptions = nullptr);
         std::shared_ptr<Operation> InvokeMethod(
-            const std::wstring& ns, const std::wstring& className, const std::wstring& methodName, std::shared_ptr<const Instance>);
-        void CreateInstance(const std::wstring& ns, const Instance& instance);
-        void ModifyInstance(const std::wstring& ns, const Instance& instance);
-        void DeleteInstance(const std::wstring& ns, const Instance& instance);
+            const std::wstring& ns, const std::wstring& className, const std::wstring& methodName, std::shared_ptr<const Instance>,
+            std::shared_ptr<OperationOptions> operationOptions = nullptr);
+        void CreateInstance(const std::wstring& ns, const Instance& instance,
+            std::shared_ptr<OperationOptions> operationOptions = nullptr);
+        void ModifyInstance(const std::wstring& ns, const Instance& instance,
+            std::shared_ptr<OperationOptions> operationOptions = nullptr);
+        void DeleteInstance(const std::wstring& ns, const Instance& instance,
+                            std::shared_ptr<OperationOptions> operationOptions = nullptr);
         std::shared_ptr<Operation> GetClass(const std::wstring& ns, const std::wstring& className);
         std::shared_ptr<Operation> GetInstance(const std::wstring& ns, const Instance& keyInstance);
         std::shared_ptr<Operation> GetAssociators(const std::wstring& ns, const Instance& instance, const std::wstring& assocClass = L"",
             const std::wstring& resultClass = L"", const std::wstring& role = L"",
-            const std::wstring& resultRole = L"", bool keysOnly = false);
+            const std::wstring& resultRole = L"", bool keysOnly = false,
+            std::shared_ptr<OperationOptions> operationOptions = nullptr);
         std::shared_ptr<Operation> Subscribe(const std::wstring& ns, const std::wstring& query, std::shared_ptr<Callbacks> callback = nullptr,
             std::shared_ptr<OperationOptions> operationOptions = nullptr, const std::wstring& dialect = L"WQL");
         void Close();

--- a/PyMI/Utils.cpp
+++ b/PyMI/Utils.cpp
@@ -502,3 +502,16 @@ void SetPyException(const std::exception& ex)
         Py_DECREF(d);
     }
 }
+
+void ValidatePyObjectType(PyObject* obj, const std::wstring& objName,
+                          PyTypeObject* expectedType, const std::wstring& expectedTypeName,
+                          bool allowNone)
+{
+    bool isNone = CheckPyNone(obj);
+
+    if ((isNone && !allowNone) ||
+        (!isNone && !PyObject_IsInstance(obj,
+                                         reinterpret_cast<PyObject*>(expectedType))))
+        throw MI::TypeConversionException(
+            L"\"" + objName + L"\"must have type " + expectedTypeName);
+}

--- a/PyMI/Utils.h
+++ b/PyMI/Utils.h
@@ -17,3 +17,6 @@ void CallPythonCallback(PyObject* callable, const char* format, ...);
 void MIIntervalFromPyDelta(PyObject* pyDelta, MI_Interval& interval);
 PyObject* PyDeltaFromMIInterval(const MI_Interval& interval);
 bool CheckPyNone(PyObject* obj);
+void ValidatePyObjectType(PyObject* obj, const std::wstring& objName,
+                          PyTypeObject* expectedType, const std::wstring& expectedTypeName,
+                          bool allowNone = true);


### PR DESCRIPTION
In some cases, we may want to ensure that certain operations will
not block undefinetely.

MI allows us to set 'global' operation timeouts, using destination
options. Also, when invoking methods we can override the default
timeouts, if needed, passing operation options.

This change exposes those timeouts, allowing setting a default timeout
using the 'DEFAULT_OPERATION_TIMEOUT' global variable. Also, invoked
methods will now accept the 'operation_timeout' kwarg.
