### PR TITLE
Add custom operation options support

### DIFF
--- a/MI/MI++.cpp
+++ b/MI/MI++.cpp
@@ -661,6 +661,16 @@ void OperationOptions::Delete()
     this->m_operationOptions = MI_OPERATIONOPTIONS_NULL;
 }
 
+void OperationOptions::SetCustomOption(const std::wstring& optionName,
+                                       MI_Type optionValueType,
+                                       const MIValue& optionValue,
+                                       MI_Boolean mustComply)
+{
+    MICheckResult(::MI_OperationOptions_SetCustomOption(
+        &this->m_operationOptions, optionName.c_str(), optionValueType,
+        &optionValue.m_value, mustComply));
+}
+
 OperationOptions::~OperationOptions()
 {
     MI_OperationOptions nullOperationOptions = MI_OPERATIONOPTIONS_NULL;

--- a/MI/MI++.h
+++ b/MI/MI++.h
@@ -92,6 +92,10 @@ namespace MI
         std::shared_ptr<OperationOptions> Clone() const;
         void SetTimeout(const MI_Interval& timeout);
         MI_Interval GetTimeout();
+        void SetCustomOption(const std::wstring& optionName,
+                             MI_Type optionValueType,
+                             const MIValue& optionValue,
+                             MI_Boolean mustComply);
         void Delete();
         virtual ~OperationOptions();
     };

--- a/MI/MIValue.h
+++ b/MI/MIValue.h
@@ -5,6 +5,7 @@
 namespace MI
 {
     class Instance;
+    class OperationOptions;
 
     class MIValue
     {
@@ -19,6 +20,7 @@ namespace MI
         void CopyWString(const std::wstring& value);
 
         friend Instance;
+        friend OperationOptions;
 
     public:
         static std::shared_ptr<MIValue> FromBoolean(MI_Boolean value);

--- a/PyMI/OperationOptions.cpp
+++ b/PyMI/OperationOptions.cpp
@@ -98,6 +98,37 @@ static PyObject* OperationOptions_SetTimeout(OperationOptions* self, PyObject* t
     }
 }
 
+
+static PyObject* OperationOptions_SetCustomOption(OperationOptions* self,  PyObject *args, PyObject *kwds)
+{
+    wchar_t* optionName = NULL;
+    unsigned int optionValueType = 0;
+    PyObject* optionValue = NULL;
+    PyObject* mustComply = NULL;
+
+    static char *kwlist[] = { "name", "value_type", "value", "must_comply", NULL };
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "uIO|O", kwlist,
+                                     &optionName, &optionValueType,
+                                     &optionValue, &mustComply))
+        return NULL;
+
+    try
+    {
+        auto miValue = Py2MI(optionValue, (MI_Type)optionValueType);
+        AllowThreads(&self->cs, [&]() {
+            self->operationOptions->SetCustomOption(optionName, (MI_Type)optionValueType,
+                                                    *miValue, PyObject_IsTrue(mustComply));
+        });
+        Py_RETURN_NONE;
+    }
+    catch (std::exception& ex)
+    {
+        SetPyException(ex);
+        return NULL;
+    }
+}
+
+
 static PyMemberDef OperationOptions_members[] = {
     { NULL }  /* Sentinel */
 };
@@ -106,6 +137,8 @@ static PyMethodDef OperationOptions_methods[] = {
     { "clone", (PyCFunction)OperationOptions_Clone, METH_NOARGS, "Clones the OperationOptions." },
     { "get_timeout", (PyCFunction)OperationOptions_GetTimeout, METH_NOARGS, "Returns the timeout." },
     { "set_timeout", (PyCFunction)OperationOptions_SetTimeout, METH_O, "Sets a timeout." },
+    { "set_custom_option", (PyCFunction)OperationOptions_SetCustomOption,
+                           METH_VARARGS | METH_KEYWORDS, "Sets a custom option." },
     { NULL }  /* Sentinel */
 };
 

--- a/PyMI/src/samples/custom_operation_options.py
+++ b/PyMI/src/samples/custom_operation_options.py
@@ -1,0 +1,25 @@
+import mi
+import wmi
+
+# This sample describes the usage of custom operation options
+# by creating a nic team.
+
+conn = wmi.WMI(moniker='root/standardcimv2')
+
+def new_lbfo_team(team_members, team_name):
+    obj = conn.MSFT_NetLbfoTeam.new()
+    obj.Name = 'nic_team'
+    custom_options = [
+        {'name': 'TeamMembers',
+         'value_type': mi.MI_ARRAY | mi.MI_STRING,
+         'value': team_members
+        },
+        {'name': 'TeamNicName',
+         'value_type': mi.MI_STRING,
+         'value': 'nic_team'}
+    ]
+    operation_options = {'custom_options': custom_options}
+    obj.put(operation_options=operation_options)
+
+new_lbfo_team(team_members=['eth2', 'eth3'],
+              team_name='nic_team')

--- a/PyMI/src/wmi/tests/functional/test_base.py
+++ b/PyMI/src/wmi/tests/functional/test_base.py
@@ -37,7 +37,8 @@ class BaseFunctionalTestCase(testtools.TestCase):
             try:
                 (fd, tmp_path) = tempfile.mkstemp(suffix='pymi-test')
                 os.close(fd)
-                kwargs['temp_file_path'] = tmp_path
+                # This will behave similar to the mock.patch decorator.
+                args += (tmp_path, )
                 return f(*args, **kwargs)
             finally:
                 if os.path.exists(tmp_path):

--- a/PyMI/src/wmi/tests/functional/test_timeouts.py
+++ b/PyMI/src/wmi/tests/functional/test_timeouts.py
@@ -13,6 +13,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
+import time
+
 import wmi
 from wmi.tests.functional import test_base
 
@@ -22,18 +25,26 @@ from wmi.tests.functional import test_base
 class OperationTimeoutTestCase(test_base.BaseFunctionalTestCase):
     def _check_op_timeout(self, f, *args, **kwargs):
         # 'f' is expected to be a method that accepts
-        # the 'operation_timeout' argument.
+        # operation options.
         self.assertRaises(wmi.x_wmi_timed_out,
                           f, *args,
-                          operation_timeout=0.001,
+                          operation_options={'operation_timeout': 0.001},
                           **kwargs)
 
     def test_query(self):
         self._check_op_timeout(self._conn_cimv2.Win32_Process)
 
-    def test_invoke_method(self):
-        disk = self._conn_storage.Msft_Disk()[0]
-        self._check_op_timeout(disk.Refresh)
+    @test_base.BaseFunctionalTestCase.pass_temp_file
+    @test_base.BaseFunctionalTestCase.pass_temp_file
+    def test_invoke_method(self, temp_src, temp_dest):
+        with open(temp_src, 'w') as f:
+            f.write('random data' * (10 << 20))
+        os.unlink(temp_dest)
+
+        datafile = self._conn_cimv2.Cim_DataFile(Name=temp_src)[0]
+        self._check_op_timeout(datafile.Copy, temp_dest)
+
+        time.sleep(0.5)
 
     def test_associators(self):
         disk = self._conn_cimv2.Win32_DiskDrive()[0]
@@ -41,10 +52,12 @@ class OperationTimeoutTestCase(test_base.BaseFunctionalTestCase):
 
     @test_base.BaseFunctionalTestCase.pass_temp_file
     def test_modify_delete(self, temp_file_path):
+        operation_options = {'operation_timeout': 1}
+
         datafile = self._conn_cimv2.Cim_DataFile(Name=temp_file_path)[0]
         datafile.Description = 'fake_description'
-        datafile.put(operation_timeout=1)
-        datafile.Delete_(operation_timeout=1)
+        datafile.put(operation_options=operation_options)
+        datafile.Delete_(operation_options=operation_options)
 
     def test_per_session_timeouts(self):
         conn = wmi.WMI(operation_timeout=0.1)
@@ -53,4 +66,4 @@ class OperationTimeoutTestCase(test_base.BaseFunctionalTestCase):
 
         # We expect the query to be successful after we override the
         # session based operation timeout.
-        conn.Win32_Process(operation_timeout=10)
+        conn.Win32_Process(operation_options={'operation_timeout': 10})


### PR DESCRIPTION
For some operations, such as creating a NIC team, custom operation
options must be passed.

This change exposes this functionality. Some methods now accept
a 'operation_options' dict that may contain a field 'custom_options'.
This needs to be a list of options, defined as dicts containing the
option name, option value and a MI value type, allowing the option
value to be 'casted' to a MI type.

A sample provided by this patch brings a better overview of this
feature.

Note that operation_timeouts are now specified within the
operation_options dict. The existing functional tests were updated
to reflect this change. Also, one of the tests that was failing
due to an expected timeout not being hit was fixed as well.
