### PR TITLE
Do an explicit unicode cast

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -553,7 +553,7 @@ class _Connection(object):
             option_value = self._unwrap_element(option['value_type'],
                                                 option['value'])
             mi_op_options.set_custom_option(
-                name=option['name'],
+                name=six.text_type(option['name']),
                 value_type=option['value_type'],
                 value=option_value,
                 must_comply=option.get('must_comply', True))


### PR DESCRIPTION
PyMI expects most of the string arguments to be unicode. No implicit
casts will be performed.

This is fine, as most of the top level Python wrapper module performs
explicit unicode casts. Except for the method setting custom operation
options, which may lead to TypeError, as seen in the following
cloudbase-init trace:

http://paste.openstack.org/show/623074/

This change ensures we do a cast in this case as well.