### PR TITLE
Add Py3.7 build config

### DIFF
--- a/MI/MI.vcxproj
+++ b/MI/MI.vcxproj
@@ -45,6 +45,14 @@
       <Configuration>Release (Python 3.5)</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Python 3.7)|Win32">
+      <Configuration>Release (Python 3.7)</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Python 3.7)|x64">
+      <Configuration>Release (Python 3.7)</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -105,6 +113,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -151,6 +166,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -181,6 +203,9 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -202,6 +227,9 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -216,6 +244,9 @@
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|Win32'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'">
@@ -360,6 +391,24 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -432,6 +481,24 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -474,10 +541,12 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.5)|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.5)|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|x64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>

--- a/PyMI.sln
+++ b/PyMI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2000
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PyMI", "PyMI\PyMI.vcxproj", "{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -26,6 +26,8 @@ Global
 		Release (Python 3.5)|x86 = Release (Python 3.5)|x86
 		Release (Python 3.6)|x64 = Release (Python 3.6)|x64
 		Release (Python 3.6)|x86 = Release (Python 3.6)|x86
+		Release (Python 3.7)|x64 = Release (Python 3.7)|x64
+		Release (Python 3.7)|x86 = Release (Python 3.7)|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Debug (Python 2.7)|x64.ActiveCfg = Debug|x64
@@ -56,6 +58,10 @@ Global
 		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Release (Python 3.6)|x64.Build.0 = Release (Python 3.6)|x64
 		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Release (Python 3.6)|x86.ActiveCfg = Release (Python 3.6)|Win32
 		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Release (Python 3.6)|x86.Build.0 = Release (Python 3.6)|Win32
+		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Release (Python 3.7)|x64.ActiveCfg = Release (Python 3.7)|x64
+		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Release (Python 3.7)|x64.Build.0 = Release (Python 3.7)|x64
+		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Release (Python 3.7)|x86.ActiveCfg = Release (Python 3.7)|Win32
+		{99CD5168-1D78-4584-A9DA-5ABF96FC89CF}.Release (Python 3.7)|x86.Build.0 = Release (Python 3.7)|Win32
 		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Debug (Python 2.7)|x64.ActiveCfg = Debug|x64
 		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Debug (Python 2.7)|x64.Build.0 = Debug|x64
 		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Debug (Python 2.7)|x86.ActiveCfg = Debug|Win32
@@ -84,8 +90,15 @@ Global
 		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Release (Python 3.6)|x64.Build.0 = Release (Python 3.6)|x64
 		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Release (Python 3.6)|x86.ActiveCfg = Release (Python 3.6)|Win32
 		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Release (Python 3.6)|x86.Build.0 = Release (Python 3.6)|Win32
+		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Release (Python 3.7)|x64.ActiveCfg = Release (Python 3.7)|x64
+		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Release (Python 3.7)|x64.Build.0 = Release (Python 3.7)|x64
+		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Release (Python 3.7)|x86.ActiveCfg = Release (Python 3.7)|Win32
+		{87DACAD9-74AA-46EE-AF08-BDB918FD13F3}.Release (Python 3.7)|x86.Build.0 = Release (Python 3.7)|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7BCA7706-CB41-4634-92EC-3DB937C8DB20}
 	EndGlobalSection
 EndGlobal

--- a/PyMI/PyMI.vcxproj
+++ b/PyMI/PyMI.vcxproj
@@ -53,6 +53,14 @@
       <Configuration>Release (Python 3.5)</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Python 3.7)|Win32">
+      <Configuration>Release (Python 3.7)</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release (Python 3.7)|x64">
+      <Configuration>Release (Python 3.7)</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -118,6 +126,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -170,6 +185,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -210,6 +232,10 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="PythonDir.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="PythonDir.props" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="PythonDir.props" />
@@ -239,6 +265,10 @@
     <Import Project="PythonDir.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="PythonDir.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="PythonDir.props" />
   </ImportGroup>
@@ -331,6 +361,14 @@
     <TargetName>mi</TargetName>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetExt>.pyd</TargetExt>
+    <IncludePath>$(PythonDir_37_x86)\include;$(IncludePath);$(SolutionDir)\MI</IncludePath>
+    <LibraryPath>$(PythonDir_37_x86)\libs;$(LibraryPath);$(SolutionDir)$(Platform)\$(Configuration)</LibraryPath>
+    <TargetName>mi</TargetName>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.pyd</TargetExt>
@@ -357,6 +395,13 @@
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(PythonDir_36_x64)\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)\MI</IncludePath>
     <LibraryPath>$(PythonDir_36_x64)\libs;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(SolutionDir)$(Platform)\$(Configuration)</LibraryPath>
+    <TargetName>mi</TargetName>
+    <TargetExt>.pyd</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(PythonDir_37_x64)\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)\MI</IncludePath>
+    <LibraryPath>$(PythonDir_37_x64)\libs;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(SolutionDir)$(Platform)\$(Configuration)</LibraryPath>
     <TargetName>mi</TargetName>
     <TargetExt>.pyd</TargetExt>
   </PropertyGroup>
@@ -572,6 +617,28 @@
       <Command>copy "$(TargetPath)" "$(ProjectDir)src\mi\" &amp;&amp; copy "$(TargetDir)\mi.pdb" "$(ProjectDir)src\mi\" &amp;&amp; cd "$(ProjectDir)" &amp;&amp; "$(PythonDir_36_x86)\python.exe" setup.py bdist_wheel --python-tag cp35</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PYMI_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>mi++.lib;mi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy "$(TargetPath)" "$(ProjectDir)src\mi\" &amp;&amp; copy "$(TargetDir)\mi.pdb" "$(ProjectDir)src\mi\" &amp;&amp; cd "$(ProjectDir)" &amp;&amp; "$(PythonDir_37_x86)\python.exe" setup.py bdist_wheel --python-tag cp37</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -660,6 +727,28 @@
       <Command>copy "$(TargetPath)" "$(ProjectDir)src\mi\" &amp;&amp; copy "$(TargetDir)\mi.pdb" "$(ProjectDir)src\mi\" &amp;&amp; cd "$(ProjectDir)" &amp;&amp; "$(PythonDir_36_x64)\python.exe" setup.py bdist_wheel --python-tag cp36</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;PYMI_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>mi++.lib;mi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy "$(TargetPath)" "$(ProjectDir)src\mi\" &amp;&amp; copy "$(TargetDir)\mi.pdb" "$(ProjectDir)src\mi\" &amp;&amp; cd "$(ProjectDir)" &amp;&amp; "$(PythonDir_37_x64)\python.exe" setup.py bdist_wheel --python-tag cp37</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -722,10 +811,12 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.5)|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.5)|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.6)|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.7)|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release (Python 3.4)|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="Utils.cpp" />

--- a/PyMI/PythonDir.props
+++ b/PyMI/PythonDir.props
@@ -10,6 +10,8 @@
     <PythonDir_34_x64>c:\Python34_x64</PythonDir_34_x64>
     <PythonDir_36_x64>c:\Python36_x64</PythonDir_36_x64>
     <PythonDir_36_x86>c:\Python36</PythonDir_36_x86>
+    <PythonDir_37_x64>c:\Python37_x64</PythonDir_37_x64>
+    <PythonDir_37_x86>c:\Python37</PythonDir_37_x86>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup />
@@ -38,6 +40,14 @@
     </BuildMacro>
     <BuildMacro Include="PythonDir_36_x86">
       <Value>$(PythonDir_36_x86)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="PythonDir_37_x64">
+      <Value>$(PythonDir_37_x64)</Value>
+      <EnvironmentVariable>true</EnvironmentVariable>
+    </BuildMacro>
+    <BuildMacro Include="PythonDir_37_x86">
+      <Value>$(PythonDir_37_x86)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>
     </BuildMacro>
   </ItemGroup>


### PR DESCRIPTION
Python 3.7 has been out for a while, we even have 3.8 alpha builds.

This patch adds the build config for py3.7.