### PR TITLE
Listener crash

### DIFF
--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -425,7 +425,7 @@ class _EventWatcher(object):
     def __init__(self, conn, wql):
         native_threading = _get_eventlet_original('threading')
 
-        self._conn_ref = weakref.ref(conn)
+        self._conn = conn
         self._events_queue = []
         self._error = None
         self._event = native_threading.Event()
@@ -464,32 +464,29 @@ class _EventWatcher(object):
         if not more_results:
             self._operation_finished.set()
 
-        if self._conn_ref:
-            conn = self._conn_ref()
-            if conn:
-                if instance:
-                    event = _Instance(conn,
-                                      instance[u"TargetInstance"].clone(),
-                                      use_conn_weak_ref=True)
-                    try:
-                        previous_inst = _Instance(
-                            conn, instance[u'PreviousInstance'].clone(),
-                            use_conn_weak_ref=True)
-                        object.__setattr__(event, 'previous', previous_inst)
-                    except (mi.error, AttributeError):
-                        # The 'PreviousInstance' attribute may be missing, for
-                        # example in case of a creation event or simply
-                        # because this field was not requested.
-                        pass
+        if instance:
+            event = _Instance(self._conn,
+                              instance[u"TargetInstance"].clone(),
+                              use_conn_weak_ref=True)
+            try:
+                previous_inst = _Instance(
+                    self._conn, instance[u'PreviousInstance'].clone(),
+                    use_conn_weak_ref=True)
+                object.__setattr__(event, 'previous', previous_inst)
+            except (mi.error, AttributeError):
+                # The 'PreviousInstance' attribute may be missing, for
+                # example in case of a creation event or simply
+                # because this field was not requested.
+                pass
 
-                    self._events_queue.append(event)
-                if error_details:
-                    self._error = (
-                        result_code, error_string,
-                        _Instance(
-                            conn, error_details.clone(),
-                            use_conn_weak_ref=True))
-                self._event.set()
+            self._events_queue.append(event)
+        if error_details:
+            self._error = (
+                result_code, error_string,
+                _Instance(
+                    self._conn, error_details.clone(),
+                    use_conn_weak_ref=True))
+        self._event.set()
 
     @avoid_blocking_call
     def _wait_for_operation_cancel(self):
@@ -510,8 +507,8 @@ class _EventWatcher(object):
         self._event.set()
         self._operation = None
         self._timeout_ms = None
-        self._conn_ref = None
         self._events_queue = []
+        self._conn = None
 
     def __del__(self):
         self.close()

--- a/PyMI/src/wmi/__init__.py
+++ b/PyMI/src/wmi/__init__.py
@@ -431,6 +431,7 @@ class _EventWatcher(object):
         self._event = native_threading.Event()
         self._operation = conn.subscribe(
             wql, self._indication_result, self.close)
+        self._operation_finished = native_threading.Event()
 
     def _process_events(self):
         if self._error:
@@ -460,6 +461,9 @@ class _EventWatcher(object):
 
     def _indication_result(self, instance, bookmark, machine_id, more_results,
                            result_code, error_string, error_details):
+        if not more_results:
+            self._operation_finished.set()
+
         if self._conn_ref:
             conn = self._conn_ref()
             if conn:
@@ -487,10 +491,22 @@ class _EventWatcher(object):
                             use_conn_weak_ref=True))
                 self._event.set()
 
+    @avoid_blocking_call
+    def _wait_for_operation_cancel(self):
+        self._operation_finished.wait()
+
     def close(self):
         if self._operation:
             self._operation.cancel()
+            # Those operations are asynchronous. We'll need to wait for the
+            # subscription to be canceled before deallocating objects,
+            # otherwise MI can crash when receiving further events. We rely on
+            # the fact that an event will be emitted once the subscription is
+            # canceled.
+            self._wait_for_operation_cancel()
+
             self._operation.close()
+
         self._event.set()
         self._operation = None
         self._timeout_ms = None


### PR DESCRIPTION
Our WMI event listener can only be used as a daemon at the moment. If it gets deallocated, MI crashes with an memory access violation error.

We have to make sure that the event subscription is properly closed before cleaning up the objects that might be used by the subscription callbacks.

Fixes: #36 