### PR TITLE
[trivial] Fix attribute error handling

### DIFF
--- a/wmi/__init__.py
+++ b/wmi/__init__.py
@@ -294,7 +294,7 @@ class _BaseEntity(object):
             try:
                 return _Method(self._conn, self, name)
             except mi.error as err:
-                if err.message['mi_result'] == (
+                if err.args[0].get('mi_result') == (
                         mi_error.MI_RESULT_METHOD_NOT_FOUND):
                     err_msg = ("'%(cls_name)s' has no attribute "
                                "'%(attr_name)s'.")


### PR DESCRIPTION
When failing to access an MI object attribute, we check if that
attribute is in fact a method. If that fails as well, we're
looking for an "MI_RESULT_METHOD_NOT_FOUND" error code.

The issue is that we aren't properly retrieving the error code.
It will still throw an attribute error (for which reason it wasn't
a big concern), but the trace can be misleading and not user friendly:
http://paste.openstack.org/raw/755512/

This change will fix this issue by correctly retrieving the error
code.