### PR TITLE
Statically link the VC runtime

### DIFF
--- a/PyMI/README.rst
+++ b/PyMI/README.rst
@@ -122,6 +122,12 @@ version, use the following:
 
     python setup.py bdist_wheel
 
+Make sure to use the Visual Studio toolset that matches the Python version
+that you're targetting: https://wiki.python.org/moin/WindowsCompilers.
+
+By default, we're statically linking the VC runtime. To enable dynamic
+linking, set ``$env:PYMI_VCRUNTIME_DYNAMIC_LINKING="y"``.
+
 Debug builds
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
Before switching to distutils, we were statically linking the
VC runtime.

distutils, on the other hand, is enforcing dynamic linking. The
reason is that some extensions were hitting some runtime
limitations when statically linking it:
https://bugs.python.org/issue38597

This admittedly hacky patch will override the hardcoded distutils
/MD flag. It should work with all the supported Python versions.
For future versions, we're probably going to request the Python
community a better way of statically linking the runtime when
aware of the limitations.