### PR TITLE
Fix building with mingw-w64.

### DIFF
--- a/MI/MI++.cpp
+++ b/MI/MI++.cpp
@@ -38,7 +38,7 @@ static void MICheckResult(MI_Result result, const MI_Instance* extError = nullpt
             Instance instance((MI_Instance*)extError, false);
             if(IsInstanceOf(instance, L"MSFT_WmiError"))
             {
-                MI_Char* message = instance[L"Message"]->m_value.string;
+                const MI_Char* message = instance[L"Message"]->m_value.string;
                 message = message ? message : L"";
 
                 auto errorCode = instance[L"error_code"]->m_value.uint32;

--- a/MI/targetver.h
+++ b/MI/targetver.h
@@ -5,4 +5,6 @@
 // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
+#define _WIN32_WINNT 0x0a00
+
 #include <SDKDDKVer.h>

--- a/PyMI/Class.cpp
+++ b/PyMI/Class.cpp
@@ -112,7 +112,7 @@ static PyObject* Class_GetClassName(Class* self, PyObject*)
 {
     try
     {
-        std::wstring& className = self->miClass->GetClassName();
+        std::wstring className = self->miClass->GetClassName();
         return PyUnicode_FromWideChar(className.c_str(), className.length());
     }
     catch (std::exception& ex)
@@ -126,7 +126,7 @@ static PyObject* Class_GetNameSpace(Class* self, PyObject*)
 {
     try
     {
-        std::wstring& nameSpace = self->miClass->GetNameSpace();
+        std::wstring nameSpace = self->miClass->GetNameSpace();
         return PyUnicode_FromWideChar(nameSpace.c_str(), nameSpace.length());
     }
     catch (std::exception& ex)
@@ -140,7 +140,7 @@ static PyObject* Class_GetServerName(Class* self, PyObject*)
 {
     try
     {
-        std::wstring& serverName = self->miClass->GetServerName();
+        std::wstring serverName = self->miClass->GetServerName();
         return PyUnicode_FromWideChar(serverName.c_str(), serverName.length());
     }
     catch (std::exception& ex)

--- a/PyMI/Instance.cpp
+++ b/PyMI/Instance.cpp
@@ -212,7 +212,7 @@ static PyObject* Instance_GetClassName(Instance *self, PyObject*)
 {
     try
     {
-        std::wstring& className = self->instance->GetClassName();
+        std::wstring className = self->instance->GetClassName();
         return PyUnicode_FromWideChar(className.c_str(), className.length());
     }
     catch (std::exception& ex)
@@ -226,7 +226,7 @@ static PyObject* Instance_GetNameSpace(Instance* self, PyObject*)
 {
     try
     {
-        std::wstring& nameSpace = self->instance->GetNameSpace();
+        std::wstring nameSpace = self->instance->GetNameSpace();
         return PyUnicode_FromWideChar(nameSpace.c_str(), nameSpace.length());
     }
     catch (std::exception& ex)
@@ -240,7 +240,7 @@ static PyObject* Instance_GetServerName(Instance* self, PyObject*)
 {
     try
     {
-        std::wstring& serverName = self->instance->GetServerName();
+        std::wstring serverName = self->instance->GetServerName();
         return PyUnicode_FromWideChar(serverName.c_str(), serverName.length());
     }
     catch (std::exception& ex)

--- a/PyMI/Utils.cpp
+++ b/PyMI/Utils.cpp
@@ -3,6 +3,7 @@
 #include "Utils.h"
 #include "instance.h"
 #include <codecvt>
+#include <locale>
 
 #include <datetime.h>
 
@@ -151,7 +152,7 @@ std::wstring Py2WString(PyObject* pyValue)
         throw MI::Exception(L"PyUnicode_AsWideChar failed");
     }
 
-    auto& value = std::wstring(w, len);
+    auto value = std::wstring(w, len);
     delete[] w;
     return value;
 }
@@ -167,9 +168,9 @@ std::shared_ptr<MI::MIValue> Py2StrMIValue(PyObject* pyValue)
     try
     {
 #ifdef IS_PY3K
-        auto& value = Py2WString(pyStrValue);
+        auto value = Py2WString(pyStrValue);
 #else
-        auto& value = std::string(PyString_AsString(pyStrValue));
+        auto value = std::string(PyString_AsString(pyStrValue));
 #endif
         Py_DECREF(pyStrValue);
         return MI::MIValue::FromString(value);
@@ -372,7 +373,7 @@ std::shared_ptr<MI::MIValue> Py2MI(PyObject* pyValue, MI_Type valueType)
                 pyObj = PyList_GetItem(pyValue, i);
             }
 
-            auto& tmpValue = Py2MI(pyObj, itemType);
+            auto tmpValue = Py2MI(pyObj, itemType);
             value->SetArrayItem(*tmpValue, (unsigned)i);
         }
         return value;

--- a/PyMI/targetver.h
+++ b/PyMI/targetver.h
@@ -5,4 +5,6 @@
 // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
+#define _WIN32_WINNT 0x0a00
+
 #include <SDKDDKVer.h>

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from distutils import _msvccompiler
 from distutils import ccompiler
 import os
 import setuptools
+import sys
 
 try:
     import multiprocessing  # noqa
@@ -37,7 +38,8 @@ def new_compiler(plat=None, compiler=None, verbose=0, dry_run=0, force=0):
     return Compiler(None, dry_run, force)
 
 
-ccompiler.new_compiler = new_compiler
+if 'MSC' in sys.version:
+    ccompiler.new_compiler = new_compiler
 
 
 # Setuptools requires relative paths


### PR DESCRIPTION
Several cases where code was trying to take a reference to an rvalue.

Include `<locale>` for `std::wstring_convert`.

Issue where mingw-w64 defaulted to 0x0502 (server 2003) instead of latest available version in SDKDDKVer.h, as mentioned in comments of targetver.h.  https://sourceforge.net/p/mingw-w64/mailman/message/37799758/

Only override new_compiler if python was built with MSC (as opposed to GCC).

See also msys2/MINGW-packages#16630