### PR TITLE
Fix msvc compiler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class Compiler(_msvccompiler.MSVCCompiler):
 
 
 def new_compiler(plat=None, compiler=None, verbose=0, dry_run=0, force=0):
-    return Compiler(None, dry_run, force)
+    return Compiler(verbose, force)
 
 
 if 'MSC' in sys.version:


### PR DESCRIPTION
See: https://github.com/pypa/setuptools/commit/754fcc21e6ca9de82ff6d2837841c4300aeb941f -> the internal constructor got its interface changed.

Fixes error:

```
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-lowuwfyu\overlay\Lib\site-packages\setuptools\_distutils\command\build_clib.py", line 91, in run
      self.compiler = new_compiler(compiler=self.compiler, force=self.force)
    File "<string>", line 38, in new_compiler
  TypeError: Compiler.__init__() takes from 1 to 3 positional arguments but 4 were given
```